### PR TITLE
Tests: Add test cases for catsay and fix some cornercases

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ https://docs.docker.com/get-started/#download-and-install-docker-desktop
 Build the image with a named tag and run it:
 ```zsh
 docker build -t firecli .
-docker run -p 9090:9090 firecli
+echo "hello" | docker run -i firecli catsay
+```
+
+### Testing
+
+To run tests locally:
+```zsh
+go test -v ./... 
 ```
 
 ### Misc Notes
@@ -28,4 +35,3 @@ go run main.go
 
 Go convention uses URLs for module names. When testing multiple modules, to run local code before committing 
 we should add a replace alias in go.mod
-

--- a/cmd/catsay_test.go
+++ b/cmd/catsay_test.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWriteWordShort(t *testing.T) {
+	www := newWriter(10)
+	out := &bytes.Buffer{}
+	error := writeWord(out, www, "foo")
+	if error != nil {
+		t.Errorf("writeWord should not return error but got %q", error)
+	}
+	expected := ". foo"
+	if out.String() != expected {
+		t.Errorf("expected %q but got %q", expected, out.String())
+	}
+}
+
+func TestWriteWordLongerThanLineLength(t *testing.T) {
+	www := newWriter(10)
+	out := &bytes.Buffer{}
+	error := writeWord(out, www, "fantastical")
+	if error != nil {
+		t.Errorf("writeWord should not return error but got %q", error)
+	}
+	expected := ". fantastic-\n. al"
+	if out.String() != expected {
+		t.Errorf("expected %q but got %q", expected, out.String())
+	}
+}
+
+func TestWriteWordExactlyOnLineWidth(t *testing.T) {
+	www := newWriter(10)
+	out := &bytes.Buffer{}
+	error := writeWord(out, www, "0123456789")
+	if error != nil {
+		t.Errorf("writeWord should not return error but got %q", error)
+	}
+	expected := ". 0123456789"
+	if out.String() != expected {
+		t.Errorf("expected %q but got %q", expected, out.String())
+	}
+}
+
+func TestWriteWordMultipleCalls(t *testing.T) {
+	var err error
+	var expected string
+	www := newWriter(10)
+	out := &bytes.Buffer{}
+	err = writeWord(out, www, "Hello")
+	if err != nil {
+		t.Errorf("writeWord should not return error but got %q", err)
+	}
+	expected = ". Hello"
+	if out.String() != expected {
+		t.Errorf("expected %q but got %q", expected, out.String())
+	}
+	err = writeWord(out, www, "World!")
+	if err != nil {
+		t.Errorf("writeWord should not return error but got %q", err)
+	}
+	expected = ". Hello      .\n. World!"
+	if out.String() != expected {
+		t.Errorf("expected %q but got %q", expected, out.String())
+	}
+}
+
+func TestLineReturn(t *testing.T) {
+	www := newWriter(10)
+	out := &bytes.Buffer{}
+	err := writeWord(out, www, "1234567890")
+	if err != nil {
+		t.Errorf("writeWord should not return error but got %q", err)
+	}
+	expected := ". 1234567890"
+	if out.String() != expected {
+		t.Errorf("expected %q but got %q", expected, out.String())
+	}
+	err = lineReturn(out, www)
+	if err != nil {
+		t.Errorf("lineReturn should not return error but got %q", err)
+	}
+	expected = ". 1234567890 .\n"
+	if out.String() != expected {
+		t.Errorf("expected %q but got %q", expected, out.String())
+	}
+}
+
+func TestLineReturnWithPadding(t *testing.T) {
+	www := newWriter(10)
+	out := &bytes.Buffer{}
+	err := writeWord(out, www, "1234567")
+	if err != nil {
+		t.Errorf("writeWord should not return error but got %q", err)
+	}
+	expected := ". 1234567"
+	if out.String() != expected {
+		t.Errorf("expected %q but got %q", expected, out.String())
+	}
+	err = lineReturn(out, www)
+	if err != nil {
+		t.Errorf("lineReturn should not return error but got %q", err)
+	}
+	expected = ". 1234567    .\n"
+	if out.String() != expected {
+		t.Errorf("expected %q but got %q", expected, out.String())
+	}
+}
+
+func TestCatsay(t *testing.T) {
+	www := newWriter(30)
+	out := &bytes.Buffer{}
+	data := []byte(`Alice was beginning to get very tired of sitting by her sister on the bank`)
+	err := catsay(out, bytes.NewReader(data), www, false)
+	if err != nil {
+		t.Errorf("catsay should not return error but got %q", err)
+	}
+	expected := "----------------------------------\n. Alice was beginning to get     .\n. very tired of sitting by her   .\n. sister on the bank             .\n"
+	if out.String() != expected {
+		t.Errorf("expected %q but got %q", expected, out.String())
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,13 +7,8 @@ import (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "firecli",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "cli playground for learning go",
+	Long:  `cli playground for learning go: it will probably have some silly commands`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,12 @@
+package cmd
+
+import "testing"
+
+func TestGetRootCmd(t *testing.T) {
+	command := GetRootCmd()
+	use := command.Use
+	expected := "firecli"
+	if use != expected {
+		t.Errorf("expected %q but got %q", expected, use)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/gwwar/firecli
 
 go 1.17
 
+require github.com/spf13/cobra v1.3.0
+
 require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/spf13/cobra v1.3.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/dl v0.0.0-20220106205509-1eec60721618 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -337,8 +337,6 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
-golang.org/dl v0.0.0-20220106205509-1eec60721618 h1:5iTRyBEPRMA5oIY2aNopm12aXzeMssneL5lIVN7TIdk=
-golang.org/dl v0.0.0-20220106205509-1eec60721618/go.mod h1:IUMfjQLJQd4UTqG1Z90tenwKoCX93Gn3MAQJMOSBsDQ=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/main.go
+++ b/main.go
@@ -2,18 +2,21 @@ package main
 
 import (
 	"github.com/gwwar/firecli/cmd"
+	"io"
 	"os"
 )
 
 type exitCode int
 
 const (
-	exitOK     exitCode = 0
-	exitError  exitCode = 1
+	exitOK    exitCode = 0
+	exitError exitCode = 1
 )
 
-func runCommand() exitCode {
-	err := cmd.GetRootCmd().Execute()
+func runCommand(out io.Writer) exitCode {
+	rootCommand := cmd.GetRootCmd()
+	rootCommand.SetOut(out)
+	err := rootCommand.Execute()
 	if err != nil {
 		return exitError
 	}
@@ -21,7 +24,6 @@ func runCommand() exitCode {
 }
 
 func main() {
-
-	code := runCommand()
+	code := runCommand(os.Stdout)
 	os.Exit(int(code))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestRunCommand(t *testing.T) {
+	out := &bytes.Buffer{}
+	exit := runCommand(out)
+	if exit != exitOK {
+		t.Errorf("expected exit with signal 0 but got %q", exit)
+	}
+	expected := "cli playground for learning go: it will probably have some silly commands\n\nUsage:\n  firecli [command]\n\nAvailable Commands:\n  catsay      A speaking cat\n  completion  Generate the autocompletion script for the specified shell\n  help        Help about any command\n\nFlags:\n  -h, --help     help for firecli\n  -t, --toggle   Help message for toggle\n\nUse \"firecli [command] --help\" for more information about a command.\n"
+	if out.String() != expected {
+		t.Errorf("expected %q but got %q", expected, out.String())
+	}
+}


### PR DESCRIPTION
This PR adds missing tests for catsay and modifies a few interfaces to make things easier to test.

| example test run | catsay output |
|-----|-----|
| <img width="745" alt="Screen Shot 2022-01-11 at 11 54 42 AM" src="https://user-images.githubusercontent.com/1270189/149011919-b893471d-15be-46eb-aedd-15d1ce169211.png"> | <img width="865" alt="catsay" src="https://user-images.githubusercontent.com/1270189/149012219-4739c60b-9da4-42f6-bf1f-e4a84e89ffa4.png"> |

To run tests:
```
go test ./... -v
```


