### PR TITLE
Add reload command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ echo "hello" | docker run -i firecli catsay
 ```
 
 Before running any commands related to prometheus, let's start up two local services:
-    - demoapp on port 2112 / A toy Go application that instruments the prometheus /metrics endpoint
-    - prometheus on port 9000 - A local prometheus monitoring service 
+- demoapp on port 2112 - A toy Go application that instruments the prometheus /metrics endpoint
+- prometheus on port 9000 - A local prometheus monitoring service 
 ```zsh
 docker-compose -d up #-d for detached mode
 ```

--- a/cmd/reload.go
+++ b/cmd/reload.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// reloadCmd represents the reload command
+var reloadCmd = &cobra.Command{
+	Use:   "reload",
+	Short: "Reloads the prometheus configuration",
+	Long:  `If changes were made to the prometheus configuration, this triggers a reload without needing to restart the service`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return reload("http://localhost:9000", os.Stdout)
+	},
+}
+
+func reload(prometheusBaseURL string, out io.Writer) error {
+	request, err := http.NewRequest(
+		http.MethodPost,
+		fmt.Sprintf("%s/-/reload", prometheusBaseURL),
+		nil)
+	if err != nil {
+		// %w wraps the error, so it can be later unwrapped with errors.Unwrap
+		return fmt.Errorf("Failed to make a reload request object: %w", err)
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("Failed to make a reload request to prometheus: %w", err)
+	}
+	if response.StatusCode == 200 {
+		fmt.Fprintln(out, "Successfully reloaded prometheus configs, visit", prometheusBaseURL)
+	} else {
+		fmt.Fprintln(out, "Failed to reload prometheus configs")
+	}
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(reloadCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// reloadCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// reloadCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/reload_test.go
+++ b/cmd/reload_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestReload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.String() == "/-/reload" {
+			w.WriteHeader(200)
+		} else {
+			w.WriteHeader(500)
+		}
+	}))
+	defer server.Close()
+
+	out := &bytes.Buffer{}
+	err := reload(server.URL, out)
+
+	if err != nil {
+		t.Errorf("reload should not return error but got %q", err)
+	}
+	prefix := "Successfully reloaded prometheus configs"
+	if !strings.HasPrefix(out.String(), prefix) {
+		t.Errorf("reload should be successful but response was %q", out.String())
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -11,8 +12,8 @@ func TestRunCommand(t *testing.T) {
 	if exit != exitOK {
 		t.Errorf("expected exit with signal 0 but got %q", exit)
 	}
-	expected := "cli playground for learning go: it will probably have some silly commands\n\nUsage:\n  firecli [command]\n\nAvailable Commands:\n  catsay      A speaking cat\n  completion  Generate the autocompletion script for the specified shell\n  help        Help about any command\n\nFlags:\n  -h, --help     help for firecli\n  -t, --toggle   Help message for toggle\n\nUse \"firecli [command] --help\" for more information about a command.\n"
-	if out.String() != expected {
-		t.Errorf("expected %q but got %q", expected, out.String())
+	prefix := "cli playground for learning go:"
+	if !strings.HasPrefix(out.String(), prefix) {
+		t.Errorf("expected to start with %q but got %q", prefix, out.String())
 	}
 }

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval: 30s
+  scrape_interval: 10s
   scrape_timeout: 10s
 
 rule_files:


### PR DESCRIPTION
This command will load in a prometheus config without restarting the prometheus instance. Internally the command makes a POST request to `/-/reload`

### Testing
- `docker-compose up -d`
- modify prometheus.yml, for example adding a new scrape target
- build and run firecli `docker build -t firecli .` `go run main.go reload`
- verify that unit tests pass with `go test -v ./...`
<img width="606" alt="reload" src="https://user-images.githubusercontent.com/1270189/149213367-9976faa7-478c-4b49-81fc-f7d30e5c27f6.png">

